### PR TITLE
firing_range_executions

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -73,6 +73,30 @@
 		new /obj/item/clothing/mask/surgical(src)
 		new /obj/item/clothing/mask/surgical(src)
 
+/obj/item/weapon/storage/box/lastrequest
+	name = "Last Request package"
+	desc = "Hope you're hungry for lead."
+	icon_state = "lastreq"
+	storage_slots = 4
+
+	New()
+		..()
+		new /obj/item/clothing/glasses/sunglasses/blindfold(src)
+		new /obj/item/weapon/lighter/zippo(src)
+		new /obj/item/weapon/storage/fancy/cigarettes/dromedaryco(src)
+		new /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle(src)
+
+
+/obj/item/weapon/storage/box/transplant
+	name = "Transplant Storage Unit"
+	desc = "Self-Cooling storage unit to keep your organs fresher than the prince of bel-air."
+	icon_state = "transplantbox_closed"
+	storage_slots = 6
+
+	New()
+		..()
+
+
 
 /obj/item/weapon/storage/box/syringes
 	name = "box of syringes"

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -156,7 +156,9 @@
 	flags = TABLEPASS
 	slot_flags = SLOT_BELT
 	storage_slots = 6
-	can_hold = list("/obj/item/clothing/mask/cigarette")
+	can_hold = list("/obj/item/clothing/mask/cigarette",
+					"/obj/item/weapon/lighter",
+					"/obj/item/weapon/reagent_containers/pill")
 	icon_type = "cigarette"
 
 /obj/item/weapon/storage/fancy/cigarettes/New()

--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -4,9 +4,10 @@
 	desc = "A thin platform with negatively-magnetized wheels."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "target_stake"
-	density = 1
+	density = 0
 	flags = CONDUCT
 	var/obj/item/target/pinned_target // the current pinned target
+	var/mob/living/buckled_mob
 
 	Move()
 		..()
@@ -16,16 +17,18 @@
 
 		else // Sanity check: if the pinned target can't be found in immediate view
 			pinned_target = null
-			density = 1
+			density = 0
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		// Putting objects on the stake. Most importantly, targets
 		if(pinned_target)
-			return // get rid of that pinned target first!
+			return // Clear the stake first!
+		if(buckled_mob)
+			return // Clear the stake first!
 
 		if(istype(W, /obj/item/target))
 			density = 0
-			W.density = 1
+			W.density = 0
 			user.drop_item(src)
 			W.loc = loc
 			W.layer = 3.1
@@ -36,7 +39,7 @@
 	attack_hand(mob/user as mob)
 		// taking pinned targets off!
 		if(pinned_target)
-			density = 1
+			density = 0
 			pinned_target.density = 0
 			pinned_target.layer = OBJ_LAYER
 
@@ -50,3 +53,91 @@
 				user << "You take the target out of the stake."
 
 			pinned_target = null
+
+
+/obj/structure/target_stake/Del()
+	unbuckle()
+	..()
+	return
+
+/obj/structure/target_stake/attack_paw(mob/user as mob)
+	return src.attack_hand(user)
+
+/obj/structure/target_stake/attack_hand(mob/user as mob)
+	manual_unbuckle(user)
+	return
+
+/obj/structure/target_stake/MouseDrop(atom/over_object)
+	return
+
+/obj/structure/target_stake/MouseDrop_T(mob/M as mob, mob/user as mob)
+	if(!istype(M)) return
+	buckle_mob(M, user)
+	return
+
+
+/obj/structure/target_stake/proc/unbuckle()
+	if(buckled_mob)
+		if(buckled_mob.buckled == src)	//this is probably unneccesary, but it doesn't hurt
+			buckled_mob.buckled = null
+			buckled_mob.anchored = initial(buckled_mob.anchored)
+			buckled_mob.update_canmove()
+			buckled_mob = null
+	return
+
+/obj/structure/target_stake/proc/manual_unbuckle(mob/user as mob)
+	if(buckled_mob)
+		if(buckled_mob.buckled == src)
+			if(buckled_mob != user)
+				buckled_mob.visible_message(\
+					"\blue [buckled_mob.name] was unbuckled by [user.name]!",\
+					"You were unbuckled from [src] by [user.name].",\
+					"You hear metal clanking")
+			else
+				buckled_mob.visible_message(\
+					"\blue [buckled_mob.name] unbuckled \himself!",\
+					"You unbuckle yourself from [src].",\
+					"You hear metal clanking")
+			unbuckle()
+			src.add_fingerprint(user)
+	return
+
+/obj/structure/target_stake/Move()
+	..()
+	if(buckled_mob)
+		if(buckled_mob.buckled == src)
+			buckled_mob.loc = src.loc
+		else
+			buckled_mob = null
+
+/obj/structure/target_stake/proc/buckle_mob(mob/M as mob, mob/user as mob)
+	if (!ticker)
+		user << "You can't buckle anyone in before the game starts."
+	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.restrained() || user.lying || user.stat || M.buckled || istype(user, /mob/living/silicon/pai) )
+		return
+	if(pinned_target)
+		return
+
+	if (istype(M, /mob/living/carbon/slime))
+		user << "The [M] is too squishy to buckle in."
+		return
+
+	unbuckle()
+
+	if (M == usr)
+		M.visible_message(\
+			"\blue [M.name] buckles in!",\
+			"You buckle yourself to [src].",\
+			"You hear metal clanking")
+	else
+		M.visible_message(\
+			"\blue [M.name] is buckled in to [src] by [user.name]!",\
+			"You are buckled in to [src] by [user.name].",\
+			"You hear metal clanking")
+	M.buckled = src
+	M.loc = src.loc
+	M.dir = src.dir
+	M.update_canmove()
+	src.buckled_mob = M
+	src.add_fingerprint(user)
+	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -746,6 +746,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 		canmove = 0
 		if( istype(buckled,/obj/structure/stool/bed/chair) )
 			lying = 0
+		if( istype(buckled,/obj/structure/target_stake) )
+			lying = 0
 		else
 			lying = 1
 	else if( stat || weakened || paralysis || resting || sleeping || (status_flags & FAKEDEATH))


### PR DESCRIPTION
-target_stake.dm now allows mobs to be buckled on to it

-mob.dm has had a line added to tell the target stake that we want it to
buckle the mob like a chair (Don't know why they made this here)

-fancy.dm cigarette packs now can hold pills and lighters

-boxes.dm added last request box and transplant storage box. Transplant
storage box is part of a WIP
