### PR TITLE
Bugfix: #548 - Adding delay to throw_item and UnarmedAttack

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -15,7 +15,7 @@
 		return
 
 	if(control_disabled || stat) return
-	next_move = world.time + 9
+	AllowedToClickAgainAfter(CLICK_CD_AI)
 
 	if(ismob(A))
 		ai_actual_track(A)
@@ -24,9 +24,8 @@
 
 
 /mob/living/silicon/ai/ClickOn(var/atom/A, params)
-	if(world.time <= next_click)
+	if(!AllowedToMoveAgain())
 		return
-	next_click = world.time + 1
 
 	if(client.buildmode) // comes after object.Click to allow buildmode gui objects to be clicked
 		build_click(src, client.buildmode, params, A)
@@ -55,9 +54,10 @@
 		CtrlClickOn(A)
 		return
 
-	if(world.time <= next_move)
+	if(!AllowedToMoveAgain())
 		return
-	next_move = world.time + 9
+		
+	AllowedToClickAgainAfter(CLICK_CD_AI)
 
 	if(aiCamera.in_camera_mode)
 		aiCamera.camera_mode_off()

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -85,6 +85,7 @@
 		return
 
 	if(in_throw_mode)
+		changeNext_move(CLICK_CD_THROW)
 		throw_item(A)
 		return
 
@@ -119,6 +120,7 @@
 			if(!resolved && A && W)
 				W.afterattack(A,src,1,params) // 1 indicates adjacency
 		else
+			changeNext_move(CLICK_CD_MELEE)
 			UnarmedAttack(A)
 		return
 
@@ -136,8 +138,7 @@
 				if(!resolved && A && W)
 					W.afterattack(A,src,1,params) // 1: clicking something Adjacent
 			else
-				if(ismob(A))
-					changeNext_move(CLICK_CD_MELEE)
+				changeNext_move(CLICK_CD_MELEE)
 				UnarmedAttack(A, 1)
 			return
 		else // non-adjacent click
@@ -167,8 +168,6 @@
 	in human click code to allow glove touches only at melee range.
 */
 /mob/proc/UnarmedAttack(var/atom/A, var/proximity_flag)
-	if(ismob(A))
-		changeNext_move(CLICK_CD_MELEE)
 	return
 
 /*

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -37,14 +37,13 @@
 	* mob/RangedAttack(atom,params) - used only ranged, only used for tk and laser eyes but could be changed
 */
 /mob/proc/ClickOn( var/atom/A, var/params )
-	if(world.time <= next_click)
+	if(!AllowedToMoveAgain())
 		return
-	next_click = world.time + 1
 
 	if(client.buildmode)
 		build_click(src, client.buildmode, params, A)
 		return
-
+	
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
@@ -64,36 +63,38 @@
 	if(modifiers["ctrl"])
 		CtrlClickOn(A)
 		return
-
+		
 	if(stat || paralysis || stunned || weakened)
 		return
-
+		
 	face_atom(A) // change direction to face what you clicked on
 
-	if(next_move > world.time) // in the year 2000...
+	if(!AllowedToMoveAgain())
 		return
-
+	
+	AllowedToClickAgainAfter(1) // prevent very speedy click spam
+	
 	if(istype(loc,/obj/mecha))
 		if(!locate(/turf) in list(A,A.loc)) // Prevents inventory from being drilled
 			return
 		var/obj/mecha/M = loc
 		return M.click_action(A,src)
-
+		
 	if(restrained())
-		changeNext_move(CLICK_CD_HANDCUFFED)
+		AllowedToClickAgainAfter(CLICK_CD_HANDCUFFED)
 		RestrainedClickOn(A)
 		return
-
+		
 	if(in_throw_mode)
-		changeNext_move(CLICK_CD_THROW)
+		AllowedToClickAgainAfter(CLICK_CD_THROW)
 		throw_item(A)
 		return
-
+		
 	var/obj/item/W = get_active_hand()
 
 	if(W == A)
 		W.attack_self(src)
-		changeNext_move(CLICK_CD_MELEE)
+		AllowedToClickAgainAfter(CLICK_CD_MELEE)
 		if(hand)
 			update_inv_l_hand(0)
 		else
@@ -107,23 +108,21 @@
 
 		// faster access to objects already on you
 		if(A in contents)
-			next_move = world.time + 6 // on your person
+			AllowedToClickAgainAfter(CLICK_CD_ACCESS_OBJECT_ON_PERSON) // on your person
 		else
-			next_move = world.time + 8 // in a box/bag or in your square
+			AllowedToClickAgainAfter(CLICK_CD_ACCESS_OBJECT_IN_BAG)
 
 		// No adjacency needed
 		if(W)
-			if(W.flags&USEDELAY)
-				next_move += 5
-
+			DelayClickByWeaponFlag(W)
 			var/resolved = A.attackby(W,src)
 			if(!resolved && A && W)
 				W.afterattack(A,src,1,params) // 1 indicates adjacency
 		else
-			changeNext_move(CLICK_CD_MELEE)
+			AllowedToClickAgainAfter(CLICK_CD_MELEE)
 			UnarmedAttack(A)
 		return
-
+		
 	if(!isturf(loc)) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
 		return
 
@@ -134,11 +133,11 @@
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example, params)
 				var/resolved = A.attackby(W,src,params)
-				changeNext_move(CLICK_CD_MELEE)
+				AllowedToClickAgainAfter(CLICK_CD_MELEE)
 				if(!resolved && A && W)
 					W.afterattack(A,src,1,params) // 1: clicking something Adjacent
 			else
-				changeNext_move(CLICK_CD_MELEE)
+				AllowedToClickAgainAfter(CLICK_CD_MELEE)
 				UnarmedAttack(A, 1)
 			return
 		else // non-adjacent click
@@ -146,11 +145,17 @@
 				W.afterattack(A,src,0,params) // 0: not Adjacent
 			else
 				RangedAttack(A, params)
-
 	return
 
-/mob/proc/changeNext_move(num)
+/mob/proc/AllowedToMoveAgain()
+	return next_move <= world.time
+	
+/mob/proc/AllowedToClickAgainAfter(num)
 	next_move = world.time + num
+	
+/mob/proc/DelayClickByWeaponFlag(var/obj/item/W) // if the weapon has the USEDELAY flag, increase the next_move by five
+	if(W.flags&USEDELAY)
+		next_move += 5
 
 // Default behavior: ignore double clicks, consider them normal clicks instead
 /mob/proc/DblClickOn(var/atom/A, var/params)
@@ -301,7 +306,7 @@
 	return
 
 /mob/living/LaserEyes(atom/A)
-	changeNext_move(CLICK_CD_RANGE)
+	AllowedToClickAgainAfter(CLICK_CD_RANGE)
 	var/turf/T = get_turf(src)
 	var/turf/U = get_turf(A)
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -45,9 +45,9 @@
 /obj/screen/item_action/Click()
 	if(!usr || !owner)
 		return 1
-	if(usr.next_move >= world.time)
+	if(!usr.AllowedToMoveAgain())
 		return
-	usr.next_move = world.time + 6
+	usr.AllowedToClickAgainAfter(CLICK_CD_CLICK_ICON)
 
 	if(usr.stat || usr.restrained() || usr.stunned || usr.lying)
 		return 1
@@ -82,7 +82,7 @@
 	name = "storage"
 
 /obj/screen/storage/Click()
-	if(world.time <= usr.next_move)
+	if(!usr.AllowedToMoveAgain())
 		return 1
 	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
 		return 1
@@ -92,7 +92,7 @@
 		var/obj/item/I = usr.get_active_hand()
 		if(I)
 			usr.ClickOn(master)
-			usr.next_move = world.time+2
+			usr.AllowedToClickAgainAfter(CLICK_CD_ACTIVATE_OBJECT)
 	return 1
 
 /obj/screen/gun
@@ -463,7 +463,7 @@
 /obj/screen/inventory/Click()
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
 	// We don't even know if it's a middle click
-	if(world.time <= usr.next_move)
+	if(!usr.AllowedToMoveAgain())
 		return 1
 	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
 		return 1
@@ -474,12 +474,12 @@
 			if(iscarbon(usr))
 				var/mob/living/carbon/C = usr
 				C.activate_hand("r")
-				usr.next_move = world.time+2
+				usr.AllowedToClickAgainAfter(CLICK_CD_ACTIVATE_OBJECT)
 		if("l_hand")
 			if(iscarbon(usr))
 				var/mob/living/carbon/C = usr
 				C.activate_hand("l")
-				usr.next_move = world.time+2
+				usr.AllowedToClickAgainAfter(CLICK_CD_ACTIVATE_OBJECT)
 		if("swap")
 			usr:swap_hand()
 		if("hand")
@@ -488,5 +488,5 @@
 			if(usr.attack_ui(slot_id))
 				usr.update_inv_l_hand(0)
 				usr.update_inv_r_hand(0)
-				usr.next_move = world.time+6
+				usr.AllowedToClickAgainAfter(CLICK_CD_CLICK_ICON)
 	return 1

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -31,8 +31,9 @@
 	if(client.buildmode)
 		build_click(src, client.buildmode, params, A)
 		return
-	if(world.time <= next_move) return
-	next_move = world.time + 8
+	if(!AllowedToMoveAgain()) 
+		return
+	AllowedToClickAgainAfter(CLICK_CD_GHOST)
 	// You are responsible for checking config.ghost_interaction when you override this function
 	// Not all of them require checking, see below
 	A.attack_ghost(src)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -150,7 +150,7 @@
 	else
 		if(isliving(src.loc))
 			return
-		user.next_move = max(user.next_move+2,world.time + 2)
+		user.AllowedToClickAgainAfter(CLICK_CD_ACTIVATE_OBJECT)
 	src.pickup(user)
 	add_fingerprint(user)
 	user.put_in_active_hand(src)
@@ -175,8 +175,7 @@
 		if(istype(src.loc, /mob/living))
 			return
 		src.pickup(user)
-		user.next_move = max(user.next_move+2,world.time + 2)
-
+		user.AllowedToClickAgainAfter(CLICK_CD_ACTIVATE_OBJECT)
 	user.put_in_active_hand(src)
 	return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -442,9 +442,9 @@
 	set name = "Resist"
 	set category = "IC"
 
-	if(!isliving(usr) || usr.next_move > world.time)
+	if(!isliving(usr) || !usr.AllowedToMoveAgain())
 		return
-	usr.next_move = world.time + 20
+	usr.AllowedToClickAgainAfter(CLICK_CD_RESIST)
 
 	var/mob/living/L = usr
 
@@ -527,7 +527,7 @@
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
 			if( C.handcuffed )
-				C.next_move = world.time + 100
+				C.AllowedToClickAgainAfter(CLICK_CD_BREAKOUT)
 				C.last_special = world.time + 100
 				C << "\red You attempt to unbuckle yourself. (This will take around 2 minutes and you need to stand still)"
 				for(var/mob/O in viewers(L))
@@ -561,7 +561,7 @@
 		//		breakout_time++ //Harder to get out of welded lockers than locked lockers
 
 		//okay, so the closet is either welded or locked... resist!!!
-		usr.next_move = world.time + 100
+		usr.AllowedToClickAgainAfter(CLICK_CD_BREAKOUT)
 		L.last_special = world.time + 100
 		L << "\red You lean on the back of \the [C] and start pushing the door open. (this will take about [breakout_time] minutes)"
 		for(var/mob/O in viewers(usr.loc))
@@ -626,7 +626,7 @@
 				ExtinguishMob()
 			return
 		if(CM.handcuffed && CM.canmove && (CM.last_special <= world.time))
-			CM.next_move = world.time + 100
+			CM.AllowedToClickAgainAfter(CLICK_CD_BREAKOUT)
 			CM.last_special = world.time + 100
 
 			var/can_break_cuffs
@@ -672,7 +672,7 @@
 						CM.drop_from_inventory(CM.handcuffed)
 
 		else if(CM.legcuffed && CM.canmove && (CM.last_special <= world.time))
-			CM.next_move = world.time + 100
+			CM.AllowedToClickAgainAfter(CLICK_CD_BREAKOUT)
 			CM.last_special = world.time + 100
 
 			var/can_break_cuffs

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -259,8 +259,9 @@ var/list/slot_equipment_priority = list( \
 		if (W)
 			W.attack_self(src)
 			update_inv_r_hand()
-	if(next_move < world.time)
-		next_move = world.time + 2
+	
+	AllowedToClickAgainAfter(CLICK_CD_ACTIVATE_OBJECT) // this is probably imperceptible
+	
 	return
 
 /*
@@ -970,9 +971,9 @@ mob/proc/yank_out_object()
 	set desc = "Remove an embedded item at the cost of bleeding and pain."
 	set src in view(1)
 
-	if(!isliving(usr) || usr.next_move > world.time)
+	if(!isliving(usr) || !usr.AllowedToMoveAgain())
 		return
-	usr.next_move = world.time + 20
+	usr.AllowedToClickAgainAfter(CLICK_CD_RESIST)
 
 	if(usr.stat == 1)
 		usr << "You are unconcious and cannot do that!"

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -108,7 +108,7 @@
 		return
 	if(state == GRAB_UPGRADING)
 		return
-	if(assailant.next_move > world.time)
+	if(!assailant.AllowedToMoveAgain())
 		return
 	if(world.time < (last_upgrade + UPGRADE_COOLDOWN))
 		return
@@ -160,7 +160,7 @@
 					assailant.attack_log += "\[[time_stamp()]\] <font color='red'>Strangled (kill intent) [affecting.name] ([affecting.ckey])</font>"
 					msg_admin_attack("[key_name_admin(assailant)] strangled (kill intent) [key_name_admin(affecting)] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[affecting.x];Y=[affecting.y];Z=[affecting.z]'>JMP</a>")
 
-					assailant.next_move = world.time + 10
+					assailant.AllowedToClickAgainAfter(CLICK_CD_STRANGLE)
 					affecting.losebreath += 1
 				else
 					assailant.visible_message("<span class='warning'>[assailant] was unable to tighten \his grip on [affecting]'s neck!</span>")

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -167,11 +167,13 @@
 	in_chamber.loc = get_turf(user)
 	in_chamber.starting = get_turf(user)
 	in_chamber.shot_from = src
-	user.next_move = world.time + 4
 	in_chamber.silenced = silenced
 	in_chamber.current = curloc
 	in_chamber.yo = targloc.y - curloc.y
 	in_chamber.xo = targloc.x - curloc.x
+	
+	user.AllowedToClickAgainAfter(CLICK_CD_RANGE) // 
+	
 	if(istype(user, /mob/living/carbon))
 		var/mob/living/carbon/mob = user
 		if(mob.shock_stage > 120)

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -897,14 +897,22 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 #define ALCOHOL_METABOLISM 0.1
 
 //Click cooldowns, in tenths of a second
+
 #define CLICK_CD_MELEE 8
 #define CLICK_CD_THROW 12
 #define CLICK_CD_RANGE 4
 #define CLICK_CD_BREAKOUT 100
 #define CLICK_CD_HANDCUFFED 10
+#define CLICK_CD_STRANGLE 10
 #define CLICK_CD_TKSTRANGLE 10
 #define CLICK_CD_POINT 10
 #define CLICK_CD_RESIST 20
+#define CLICK_CD_ACCESS_OBJECT_ON_PERSON 6
+#define CLICK_CD_ACCESS_OBJECT_IN_BAG 8
+#define CLICK_CD_AI 9
+#define CLICK_CD_ACTIVATE_OBJECT 2
+#define CLICK_CD_GHOST 8
+#define CLICK_CD_CLICK_ICON 6
 
 // NanoUI flags
 #define STATUS_INTERACTIVE 2 // GREEN Visability

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -898,6 +898,7 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 
 //Click cooldowns, in tenths of a second
 #define CLICK_CD_MELEE 8
+#define CLICK_CD_THROW 12
 #define CLICK_CD_RANGE 4
 #define CLICK_CD_BREAKOUT 100
 #define CLICK_CD_HANDCUFFED 10


### PR DESCRIPTION
Adding a delay to throw_item and UnarmedAttack click events.

Throw_Item's delay was set to 12, slightly slower than UnarmedAttack. 

Appears to have fixed all of the issues raised in the bug report with the exception of throwing a mob. I couldn't figure out how to do that quickly in the first place.