### PR TITLE
Fixing Borg Vision Bug

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -226,10 +226,10 @@
 	else
 		//Modules display is hidden
 		r.client.screen -= r.throw_icon	//"store" icon
-
-		for(var/atom/A in r.module.modules)
-			if( (A != r.module_state_1) && (A != r.module_state_2) && (A != r.module_state_3) )
-				//Module is not currently active
-				r.client.screen -= A
+		if(r.module)
+			for(var/atom/A in r.module.modules)
+				if( (A != r.module_state_1) && (A != r.module_state_2) && (A != r.module_state_3) )
+					//Module is not currently active
+					r.client.screen -= A
 		r.shown_robot_modules = 0
 		r.client.screen -= r.robot_modules_background

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -89,7 +89,8 @@
 	O.layer = 20 // this bit moves the target object into the robot, and moves it's location on screen
 	contents += O
 	if(istype(O,/obj/item/borg/sight))
-		sight_mode |= module_state_1:sight_mode
+		var/obj/item/borg/sight/S = O
+		sight_mode |= S.sight_mode
 	
 	if (selected) // replaces your selection if you're swapping
 		select_module(selected)


### PR DESCRIPTION
Borg vision module objects wouldn't work if they were placed in the second or module slots. This fixes that, and a run-time error caused by the inventory prior to selecting a module.