### PR TITLE
Update brain_item.dm

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -14,7 +14,8 @@
 	prosthetic_name = "cyberbrain"
 	prosthetic_icon = "brain-prosthetic"
 	organ_tag = "brain"
-
+	organ_type = /datum/organ/internal/brain
+	
 	var/mob/living/carbon/brain/brainmob = null
 
 /obj/item/organ/brain/xeno


### PR DESCRIPTION
Adding a missing tag to /obj/item/organ/brain
missing tag organ_type was preventing replacement surgery for the affected organ from functioning properly.

-Example organ: Heart object
/obj/item/organ/heart
	name = "heart"
	icon_state = "heart-on"
	prosthetic_name = "circulatory pump"
	prosthetic_icon = "heart-prosthetic"
	organ_tag = "heart"
	fresh = 6 // Juicy.
	dead_icon = "heart-off"
	organ_type = /datum/organ/internal/heart //this var is missing in the original brain object