### PR TITLE
Fixes shotgun shell sprite issues, as described in issue #612.

### DIFF
--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -81,7 +81,8 @@
 /obj/item/ammo_casing/shotgun
 	name = "shotgun shell"
 	desc = "A 12 gauge shell."
-	icon_state = "gshell"
+	icon_state = "gshell-live"
+	var/spent_state = "gshell"
 	caliber = "shotgun"
 	projectile_type = "/obj/item/projectile/bullet"
 	matter = list("metal" = 12500)
@@ -89,14 +90,16 @@
 /obj/item/ammo_casing/shotgun/incendiary
 	name = "shotgun shell"
 	desc = "A 12 gauge shell."
-	icon_state = "ishell"
+	icon_state = "ishell-live"
+	spent_state = "ishell"
 	projectile_type = "/obj/item/projectile/bullet/incendiary/shell"
 
 
 /obj/item/ammo_casing/shotgun/blank
 	name = "shotgun shell"
 	desc = "A blank shell."
-	icon_state = "blshell"
+	icon_state = "blshell-live"
+	spent_state = "blshell"
 	projectile_type = ""
 	matter = list("metal" = 250)
 
@@ -104,7 +107,8 @@
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag shell"
 	desc = "A weak beanbag shell."
-	icon_state = "bshell"
+	icon_state = "bshell-live"
+	spent_state = "bshell"
 	projectile_type = "/obj/item/projectile/bullet/weakbullet/beanbag"
 	matter = list("metal" = 500)
 
@@ -112,7 +116,8 @@
 /obj/item/ammo_casing/shotgun/stunshell
 	name = "stun shell"
 	desc = "A stunning shell."
-	icon_state = "stunshell"
+	icon_state = "stunshell-live"
+	spent_state = "stunshell"
 	projectile_type = "/obj/item/projectile/bullet/stunshot"
 	matter = list("metal" = 2500)
 
@@ -121,6 +126,7 @@
 	name = "shotgun darts"
 	desc = "A dart for use in shotguns."
 	icon_state = "dart"
+	spent_state = "dart" //I'm not sure if this has a sprite (can't find one in ammo.dmi) but this will stop it from turning into a red shell magically.
 	projectile_type = "/obj/item/projectile/energy/dart"
 	matter = list("metal" = 12500)
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -24,7 +24,7 @@
 	ammo_type = "/obj/item/ammo_casing/shotgun/beanbag"
 	var/recentpump = 0 // to prevent spammage
 	var/pumped = 0
-	var/obj/item/ammo_casing/current_shell = null
+	var/obj/item/ammo_casing/shotgun/current_shell = null
 
 	accuracy = -40 //-60 full accuracy up to 3 tiles unaimed. aimed 5 tiles accurate.  40% misschance at 7.
 	rangedrop = 5 //loses 20 accuracy per distance tile. unaimed 70% chance to miss at 7 tiles.
@@ -48,6 +48,9 @@
 		if(!wielded)
 			user << "<span class='warning'>You need to use two hands to fire this.</span>"
 			return 0
+		if(current_shell)
+			current_shell.icon_state = current_shell.spent_state
+			current_shell.desc += " This one is spent."
 		..()
 
 	attack_self(mob/living/user as mob)
@@ -119,9 +122,10 @@
 		if(!loaded.len)
 			return 0
 
-		var/obj/item/ammo_casing/AC = loaded[1] //load next casing.
+		var/obj/item/ammo_casing/shotgun/AC = loaded[1] //load next casing.
 		loaded -= AC //Remove casing from loaded list.
 		AC.desc += " This one is spent."
+		AC.icon_state = AC.spent_state
 
 		if(AC.BB)
 			in_chamber = AC.BB //Load projectile into chamber.


### PR DESCRIPTION
Shotgun shells should now have the proper sprite after being fired, fixing the issue in #612. They should also have the proper sprite before being fired, as it seems shotgun shells at the moment use the spent sprites no matter what.