### PR TITLE
Magnetic Gripper for Engineering Cyborg

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -16,7 +16,7 @@
 	var/locked = 1
 
 	attack_self(mob/user as mob)
-		if (!ishuman(user) && !istype(user,/mob/living/silicon/robot/drone))
+		if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
 			return ..(user)
 
 		var/mob/living/carbon/human/H = user

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -49,7 +49,7 @@
 
 	set name = "Drop Item"
 	set desc = "Release an item from your magnetic gripper."
-	set category = "Drone"
+	set category = "Robot Commands"
 
 	if(!wrapped)
 		//There's some weirdness with items being lost inside the arm. Trying to fix all cases. ~Z
@@ -64,14 +64,14 @@
 	src.loc << "\red You drop \the [wrapped]."
 	wrapped.loc = get_turf(src)
 	wrapped = null
-	//update_icon()
+	update_wrapped()
 
 /obj/item/weapon/gripper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	return
 
 /obj/item/weapon/gripper/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, proximity, params)
-
 	if(!target || !proximity) //Target is invalid or we are not adjacent.
+		update_wrapped()
 		return
 
 	//There's some weirdness with items being lost inside the arm. Trying to fix all cases. ~Z
@@ -93,6 +93,7 @@
 			wrapped.loc = src
 		else
 			wrapped = null
+			update_wrapped()
 			return
 
 	else if(istype(target,/obj/item)) //Check that we're not pocketing a mob.
@@ -115,27 +116,42 @@
 			user << "You collect \the [I]."
 			I.loc = src
 			wrapped = I
+			update_wrapped()
 			return
 		else
 			user << "\red Your gripper cannot hold \the [target]."
-
+			update_wrapped()
 	else if(istype(target,/obj/machinery/power/apc))
 		var/obj/machinery/power/apc/A = target
 		if(A.opened)
 			if(A.cell)
-
 				wrapped = A.cell
-
 				A.cell.add_fingerprint(user)
 				A.cell.updateicon()
 				A.cell.loc = src
 				A.cell = null
-
 				A.charging = 0
 				A.update_icon()
-
 				user.visible_message("\red [user] removes the power cell from [A]!", "You remove the power cell.")
-
+				update_wrapped()
+				
+/obj/item/weapon/gripper/proc/update_wrapped()
+	update_name()
+	update_overlay()
+	
+				
+/obj/item/weapon/gripper/proc/update_name()
+	name = initial(name)
+	if (wrapped)
+		name += " ([wrapped])"
+		
+				
+/obj/item/weapon/gripper/proc/update_overlay()
+	overlays.Cut()
+	if (wrapped)
+		overlays+=wrapped
+		
+				
 //TODO: Matter decompiler.
 /obj/item/weapon/matter_decompiler
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -231,10 +231,8 @@
 		src.modules += new /obj/item/device/flashlight(src)
 		src.modules += new /obj/item/device/flash(src)
 		src.modules += new /obj/item/borg/sight/meson(src)
-		src.emag = new /obj/item/borg/stun(src)
 		src.modules += new /obj/item/weapon/rcd/borg(src)
 		src.modules += new /obj/item/weapon/extinguisher(src)
-//		src.modules += new /obj/item/device/flashlight(src)
 		src.modules += new /obj/item/weapon/weldingtool/largetank(src)
 		src.modules += new /obj/item/weapon/screwdriver(src)
 		src.modules += new /obj/item/weapon/wrench(src)
@@ -244,7 +242,10 @@
 		src.modules += new /obj/item/device/t_scanner(src)
 		src.modules += new /obj/item/device/analyzer(src)
 		src.modules += new /obj/item/taperoll/engineering(src)
-
+		src.modules += new /obj/item/weapon/gripper(src)
+		
+		src.emag = new /obj/item/borg/stun(src)
+		
 		var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
 		M.amount = 50
 		src.modules += M


### PR DESCRIPTION
This also modifies the gripper to display the name of the object held,
and the icon for the object held as well (though it's showing as an
underlay rather than an overlay because of the way the backpack works).