### PR TITLE
Sql updates

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -148,6 +148,7 @@ Implants;
 	var/surviving_total = 0
 	var/ghosts = 0
 	var/escaped_humans = 0
+	var/species_stats = list("Humans" = 0, "Unathi" = 0, "Tajaran" = 0, "Skrell" = 0, "Vaurca" = 0, "IPC" = 0, "Diona" = 0)
 	var/escaped_total = 0
 	var/escaped_on_pod_1 = 0
 	var/escaped_on_pod_2 = 0
@@ -165,6 +166,23 @@ Implants;
 					surviving_humans++
 					if(M.loc && M.loc.loc && M.loc.loc.type in escape_locations)
 						escaped_humans++
+				var/mob/living/carbon/human/H = M
+				if (H.species)
+					switch (H.species.name)
+						if ("Human")
+							species_stats["Human"]++
+						if ("Unathi")
+							species_stats["Unathi"]++
+						if ("Tajaran")
+							species_stats["Tajaran"]++
+						if ("Skrell")
+							species_stats["Skrell"]++
+						if ("Vaurca")
+							species_stats["Vaurca"]++
+						if ("Machine")
+							species_stats["IPC"]++
+						if ("Diona")
+							species_stats["Diona"]++
 			if(!M.stat)
 				surviving_total++
 				if(M.loc && M.loc.loc && M.loc.loc.type in escape_locations)
@@ -191,6 +209,12 @@ Implants;
 		feedback_set("round_end_ghosts",ghosts)
 	if(surviving_humans > 0)
 		feedback_set("survived_human",surviving_humans)
+
+		var/species_stats_string = ""
+		for (var/species_name in species_stats)
+			species_stats_string += "[species_name]: [species_stats[species_name]], "
+
+		feedback_set("species_statistics", species_stats_string)
 	if(surviving_total > 0)
 		feedback_set("survived_total",surviving_total)
 	if(escaped_humans > 0)

--- a/code/world.dm
+++ b/code/world.dm
@@ -423,4 +423,15 @@ proc/establish_db_connection()
 	else
 		return 1
 
+//This proc disconnects the database forcefully, and then establishes connection again.
+proc/cycle_db_connection()
+	if (!dbcon)
+		return 0
+
+	log_debug("Cycling database connection.")
+	dbcon.Disconnect()
+
+	sleep(5)
+	setup_database_connection()
+
 #undef FAILED_DB_CONNECTION_CUTOFF


### PR DESCRIPTION
* Integrates the logging of all SQL errors whenever Execute() is called. They go through log_debug(), prefixed with "SQL Error:", for easy searching of the logs.
* Fixes parseArguments() proc in dbcore.dm. Actually makes it work and cleans up my sillyness with it.
* Integrates the logging of species played statistics. As per the round end feedback reports, species_statistics now collects all the numbers forever.
* Adds a proc cycle_db_connection() to world.dm. Forcefully disconnects the database, and then attempts to re-establish connection. Apart of attempts to fix database connectivity.